### PR TITLE
Fixed inversed logic for starting the timer

### DIFF
--- a/src/remote_dread_lua_console/lua_executor.py
+++ b/src/remote_dread_lua_console/lua_executor.py
@@ -89,7 +89,7 @@ class LuaExecutor(QObject):
         self._ip = value
 
     def emit_new_message(self, new_message: str):
-        start_timer = len(self.pending_messages) > 0
+        start_timer = len(self.pending_messages) == 0
         self.pending_messages.append(new_message)
         if start_timer:
             QtCore.QTimer.singleShot(200, self.window_signals.log_for_window.emit)


### PR DESCRIPTION
I was wondering why I always receive the answers only if I have at least two messages.
Had a brain fart on the boolean. 
Start the timer if there is no pending messages and not if there is a message 